### PR TITLE
docs: fix broken integration test links in contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ To run the integration tests, use the following command:
 npm run test:e2e
 ```
 
-For more detailed information on the integration testing framework, please see the [Integration Tests documentation](./docs/integration-tests.md).
+For more detailed information on the integration testing framework, please see the [Integration Tests documentation](./docs/developers/development/integration-tests.md).
 
 ### Linting and Preflight Checks
 

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -135,7 +135,7 @@ To run the integration tests, use the following command:
 npm run test:e2e
 ```
 
-For more detailed information on the integration testing framework, please see the [Integration Tests documentation](./docs/integration-tests.md).
+For more detailed information on the integration testing framework, please see the [Integration Tests documentation](./development/integration-tests.md).
 
 ### Linting and Preflight Checks
 


### PR DESCRIPTION
## TLDR
Fix two broken documentation links in contributing guides so they point to the existing integration tests doc.

## What changed
- `CONTRIBUTING.md`: `./docs/integration-tests.md` -> `./docs/developers/development/integration-tests.md`
- `docs/developers/contributing.md`: `./docs/integration-tests.md` -> `./development/integration-tests.md`

## Why
The original target `docs/integration-tests.md` does not exist, so the links are broken.

## Validation
- Verified both new targets exist in the repository.
- Docs-only change; no runtime impact.

## Linked issues / bugs
None (docs-only link fix).
