### PR TITLE
fix(openai-provider): GPT-5 reasoning model compat on /v1/chat/completions

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -323,8 +323,15 @@ export class ContentGenerationPipeline {
       return {};
     }
 
+    // GPT-5.x does not support reasoning_effort + function tools via
+    // /v1/chat/completions (requires /v1/responses). Skip the param unless
+    // explicitly opted in via reasoning.effort.
+    if (!reasoning?.effort) {
+      return {};
+    }
+
     return {
-      reasoning_effort: reasoning?.effort ?? 'medium',
+      reasoning_effort: reasoning.effort,
     };
   }
 

--- a/packages/core/src/core/openaiContentGenerator/provider/default.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.ts
@@ -56,8 +56,8 @@ export class DefaultOpenAICompatibleProvider implements OpenAICompatibleProvider
   }
 
   getDefaultGenerationConfig(): GenerateContentConfig {
-    return {
-      topP: 0.95,
-    };
+    // GPT-5 / o-series reasoning models reject top_p; do not inject a default.
+    // Users can still set samplingParams.top_p explicitly if their model accepts it.
+    return {};
   }
 }


### PR DESCRIPTION
## Summary

OpenGame's OpenAI-compat content generator currently fails out of the box against modern OpenAI reasoning models (gpt-5, gpt-5.4, gpt-5.5, o-series) before any tool call lands. Two unconditionally-injected request parameters trip 400 errors:

1. \`Unsupported parameter: 'top_p' is not supported with this model.\`
2. \`Function tools with reasoning_effort are not supported for gpt-5.x in /v1/chat/completions. Please use /v1/responses instead.\`

This PR drops both as defaults so the same code path works against current OpenAI models without forcing every user to migrate to the Responses API.

## Changes

**\`packages/core/src/core/openaiContentGenerator/provider/default.ts\`**
The default OpenAI provider returned \`{ topP: 0.95 }\` from \`getDefaultGenerationConfig()\`, which propagated to every request even when no \`samplingParams.top_p\` was configured. GPT-5 / o-series reasoning models reject \`top_p\`. Default is now \`{}\`. Users who want a specific \`top_p\` can still set \`samplingParams.top_p\` explicitly. Non-reasoning models that previously relied on the implicit 0.95 will fall through to OpenAI's server-side default (1.0), which is a benign behavior change for chat use cases.

**\`packages/core/src/core/openaiContentGenerator/pipeline.ts\`**
\`buildReasoningConfig()\` always emitted \`reasoning_effort: 'medium'\` unless \`reasoning\` was explicitly set to \`false\`. Combined with function tools on \`/v1/chat/completions\`, GPT-5.x rejects this combination. Now only emits \`reasoning_effort\` when \`reasoning.effort\` is explicitly provided. Reasoning models default to medium server-side anyway, so this preserves the original intent without tripping the constraint.

## Why not switch to /v1/responses instead?

That's a much bigger surgery — the rest of the agent loop (streaming, function-tool round-tripping, schema-compliance handling) is built around the chat-completions shape. Dropping the two params keeps the existing path working for any OpenAI-compat endpoint while leaving \`/v1/responses\` as future work.

## Verification

End-to-end run against current OpenAI models on \`/v1/chat/completions\`:

- Main agent: \`gpt-5.5\`
- Reasoning provider (classify-game-type, generate-gdd): \`gpt-4.1-mini\`
- Image: \`gpt-image-2\`
- Audio: \`gpt-4.1-mini\`

Full \`classify → generate-gdd → generate-assets → scaffold → write code → npm install → npm test → npm run build\` pipeline completes for a Castlevania-style platformer prompt. Generated game builds and runs.

## Test plan

- [ ] CI passes
- [ ] Sanity check against gpt-4o / gpt-4o-mini (non-reasoning, previously relied on top_p default) — should still work; OpenAI server default is 1.0
- [ ] Sanity check against Qwen / DashScope (those providers have their own \`getDefaultGenerationConfig()\` overrides, so unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)