### PR TITLE
fix(tongyi): remove Bearer prefix from DashScope authorization headers

### DIFF
--- a/packages/core/src/services/assetImageService.ts
+++ b/packages/core/src/services/assetImageService.ts
@@ -59,7 +59,7 @@ export class TongyiImageService extends BaseService {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.config.apiKey}`,
+        Authorization: `${this.config.apiKey}`,
         'X-DashScope-Async': 'enable',
       },
       body: JSON.stringify(payload),
@@ -84,7 +84,7 @@ export class TongyiImageService extends BaseService {
 
     const taskUrl = `${this.config.baseUrl}/api/v1/tasks/${taskId}`;
     const result = await this.pollTaskStatus(taskUrl, {
-      Authorization: `Bearer ${this.config.apiKey}`,
+      Authorization: `${this.config.apiKey}`,
     });
 
     const resultUrl = result.output?.results?.[0]?.url;
@@ -122,7 +122,7 @@ export class TongyiImageService extends BaseService {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.config.apiKey}`,
+        Authorization: `${this.config.apiKey}`,
       },
       body: JSON.stringify(payload),
     });
@@ -208,7 +208,7 @@ export class TongyiImageService extends BaseService {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.config.apiKey}`,
+        Authorization: `${this.config.apiKey}`,
         'X-DashScope-Async': 'enable',
       },
       body: JSON.stringify(payload),
@@ -233,7 +233,7 @@ export class TongyiImageService extends BaseService {
 
     const taskUrl = `${this.config.baseUrl}/api/v1/tasks/${taskId}`;
     const result = await this.pollTaskStatus(taskUrl, {
-      Authorization: `Bearer ${this.config.apiKey}`,
+      Authorization: `${this.config.apiKey}`,
     });
 
     const resultUrl = result.output?.results?.[0]?.url;
@@ -272,7 +272,7 @@ export class TongyiImageService extends BaseService {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.config.apiKey}`,
+        Authorization: `${this.config.apiKey}`,
         'X-DashScope-Async': 'enable',
       },
       body: JSON.stringify(payload),
@@ -295,7 +295,7 @@ export class TongyiImageService extends BaseService {
 
     const taskUrl = `${this.config.baseUrl}/api/v1/tasks/${taskId}`;
     const result = await this.pollTaskStatus(taskUrl, {
-      Authorization: `Bearer ${this.config.apiKey}`,
+      Authorization: `${this.config.apiKey}`,
     });
 
     const resultUrl = result.output?.results?.[0]?.url;

--- a/packages/core/src/services/assetVideoService.ts
+++ b/packages/core/src/services/assetVideoService.ts
@@ -75,7 +75,7 @@ export class TongyiVideoService extends BaseService {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.config.apiKey}`,
+        Authorization: `${this.config.apiKey}`,
         'X-DashScope-Async': 'enable',
       },
       body: JSON.stringify(payload),
@@ -102,7 +102,7 @@ export class TongyiVideoService extends BaseService {
     const result = await this.pollTaskStatus(
       taskUrl,
       {
-        Authorization: `Bearer ${this.config.apiKey}`,
+        Authorization: `${this.config.apiKey}`,
       },
       600000,
       10000,


### PR DESCRIPTION
## Summary

Fix the Alibaba Bailian (DashScope/Tongyi) API authentication by removing the "Bearer " prefix from Authorization headers.

## Root Cause

The DashScope API expects the raw apiKey directly in the Authorization header:
```
Authorization: <apiKey>
```

Not the Bearer-scheme format used by OpenAI-compatible and Doubao gateways:
```
Authorization: Bearer <apiKey>
```

`TongyiImageService` and `TongyiVideoService` were incorrectly prepending `Bearer `, causing auth failures. `DoubaoImageService`, `DoubaoVideoService`, and `OpenAICompatImageService` correctly keep the `Bearer ` prefix since their gateways require it.

## Changes

- `packages/core/src/services/assetImageService.ts` — 7 Authorization headers in `TongyiImageService` updated (sync/async generation, wanx edit, I2I edit, task polling)
- `packages/core/src/services/assetVideoService.ts` — 2 Authorization headers in `TongyiVideoService` updated (submit request + task polling)

## Scope

Tongyi service classes only. Doubao and OpenAI-compat providers are intentionally unchanged. All changes are in the framework core services layer — no extra scripts or configuration required.